### PR TITLE
Fix strict standards in TransactionManager

### DIFF
--- a/src/EventStore/TransactionManager.php
+++ b/src/EventStore/TransactionManager.php
@@ -168,6 +168,7 @@ final class TransactionManager implements ActionEventListenerAggregate
      */
     public function onEventStoreAppendToStream(ActionEvent $appendToStreamEvent)
     {
-        $this->handleRecordedEvents($appendToStreamEvent->getParam('streamEvents'));
+        $streamEvents = $appendToStreamEvent->getParam('streamEvents');
+        $this->handleRecordedEvents($streamEvents);
     }
 }

--- a/src/EventStore/TransactionManager.php
+++ b/src/EventStore/TransactionManager.php
@@ -160,7 +160,8 @@ final class TransactionManager implements ActionEventListenerAggregate
      */
     public function onEventStoreCreateStream(ActionEvent $createEvent)
     {
-        $this->handleRecordedEvents($createEvent->getParam('stream')->streamEvents());
+        $streamEvents = $createEvent->getParam('stream')->streamEvents();
+        $this->handleRecordedEvents($streamEvents);
     }
 
     /**


### PR DESCRIPTION
Fixes: PHP Strict standards:  Only variables should be passed by reference in proophessor-do/vendor/prooph/proophessor/src/EventStore/TransactionManager.php on line 171