### PR TITLE
Reset TransactionManager::inTransaction after commit

### DIFF
--- a/src/EventStore/TransactionManager.php
+++ b/src/EventStore/TransactionManager.php
@@ -152,6 +152,7 @@ final class TransactionManager implements ActionEventListenerAggregate
         if (! $this->inTransaction) return;
 
         $this->eventStore->commit();
+        $this->inTransaction = false;
         $this->currentCommand = null;
     }
 


### PR DESCRIPTION
The inTransaction flag of the TransactionManager should be reset after successful commit.