### PR TITLE
Hotfix/nested transaction support

### DIFF
--- a/spec/EventStore/TransactionManagerSpec.php
+++ b/spec/EventStore/TransactionManagerSpec.php
@@ -109,20 +109,15 @@ class TransactionManagerSpec extends ObjectBehavior
         $this->onFinalize($commandDispatch);
     }
 
-    function it_handles_nested_transactions_by_invoking_event_store_commit_only_when_all_commands_are_dispatched(EventStore $eventStore, CommandDispatch $commandDispatch)
+    function it_handles_nested_transactions(EventStore $eventStore, CommandDispatch $commandDispatch)
     {
-        $eventStore->beginTransaction()->shouldBeCalled();
-
-        $this->onInitialize($commandDispatch);
-        $this->onInitialize($commandDispatch);
-
-        $eventStore->commit()->shouldNotBeCalled();
+        $eventStore->beginTransaction()->shouldBeCalledTimes(2);
+        $eventStore->commit()->shouldBeCalledTimes(2);
         $commandDispatch->getException()->shouldBeCalled();
 
+        $this->onInitialize($commandDispatch);
+        $this->onInitialize($commandDispatch);
         $this->onFinalize($commandDispatch);
-
-        $eventStore->commit()->shouldBeCalled();
-
         $this->onFinalize($commandDispatch);
     }
 

--- a/spec/EventStore/TransactionManagerSpec.php
+++ b/spec/EventStore/TransactionManagerSpec.php
@@ -87,16 +87,7 @@ class TransactionManagerSpec extends ObjectBehavior
 
         $this->onFinalize($commandDispatch);
     }
-
-    function it_does_not_perform_a_rollback_when_it_is_not_in_transaction(EventStore $eventStore, CommandDispatch $commandDispatch)
-    {
-        $eventStore->rollback()->shouldNotBeCalled();
-
-        $commandDispatch->getException()->willReturn(new \Exception());
-
-        $this->onFinalize($commandDispatch);
-    }
-
+    
     function it_commits_the_transaction_on_finalize(EventStore $eventStore, CommandDispatch $commandDispatch)
     {
         $eventStore->beginTransaction()->shouldBeCalled();
@@ -131,14 +122,6 @@ class TransactionManagerSpec extends ObjectBehavior
         $eventStore->commit()->shouldNotBeCalled();
 
         $commandDispatch->getCommand()->willReturn($autoCommitCommand);
-
-        $this->onFinalize($commandDispatch);
-    }
-
-    function it_does_not_commit_transaction_when_it_is_not_in_transaction(EventStore $eventStore, CommandDispatch $commandDispatch)
-    {
-        $commandDispatch->getException()->shouldBeCalled();
-        $eventStore->commit()->shouldNotBeCalled();
 
         $this->onFinalize($commandDispatch);
     }

--- a/src/EventStore/TransactionManager.php
+++ b/src/EventStore/TransactionManager.php
@@ -41,11 +41,6 @@ final class TransactionManager implements ActionEventListenerAggregate
     private $eventStore;
 
     /**
-     * @var int
-     */
-    private $transactionCount = 0;
-
-    /**
      * @var Command
      */
     private $currentCommand;
@@ -124,7 +119,6 @@ final class TransactionManager implements ActionEventListenerAggregate
 
         if ($command instanceof Command && !$command instanceof AutoCommitCommand) {
             $this->eventStore->beginTransaction();
-            $this->transactionCount++;
             $this->currentCommand = $command;
         }
     }
@@ -132,10 +126,8 @@ final class TransactionManager implements ActionEventListenerAggregate
     public function onError(CommandDispatch $commandDispatch)
     {
         if (! $commandDispatch->getCommand() instanceof Command || $commandDispatch->getCommand() instanceof AutoCommitCommand) return;
-        if ($this->transactionCount === 0) return;
 
         $this->eventStore->rollback();
-        $this->transactionCount = 0;
         $this->currentCommand = null;
     }
 
@@ -147,10 +139,8 @@ final class TransactionManager implements ActionEventListenerAggregate
         }
 
         if (! $commandDispatch->getCommand() instanceof Command || $commandDispatch->getCommand() instanceof AutoCommitCommand) return;
-        if ($this->transactionCount === 0) return;
 
         $this->eventStore->commit();
-        $this->transactionCount--;
         $this->currentCommand = null;
     }
 

--- a/src/EventStore/TransactionManager.php
+++ b/src/EventStore/TransactionManager.php
@@ -40,6 +40,9 @@ final class TransactionManager implements ActionEventListenerAggregate
      */
     private $eventStore;
 
+    /**
+     * @var int
+     */
     private $transactionCount = 0;
 
     /**
@@ -120,10 +123,7 @@ final class TransactionManager implements ActionEventListenerAggregate
         $command = $commandDispatch->getCommand();
 
         if ($command instanceof Command && !$command instanceof AutoCommitCommand) {
-            if ($this->transactionCount === 0) {
-                $this->eventStore->beginTransaction();
-            }
-
+            $this->eventStore->beginTransaction();
             $this->transactionCount++;
             $this->currentCommand = $command;
         }
@@ -149,9 +149,7 @@ final class TransactionManager implements ActionEventListenerAggregate
         if (! $commandDispatch->getCommand() instanceof Command || $commandDispatch->getCommand() instanceof AutoCommitCommand) return;
         if ($this->transactionCount === 0) return;
 
-        if ($this->transactionCount === 1) {
-            $this->eventStore->commit();
-        }
+        $this->eventStore->commit();
         $this->transactionCount--;
         $this->currentCommand = null;
     }


### PR DESCRIPTION
PES was updated to support nested transactions so the TransactionManager can proxy to the event store transaction handling instead of tracking the nesting level by itself.