### PR TITLE
Added bookdown.io documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ nbproject
 .settings
 vendor
 composer.lock
+docs/html

--- a/README.md
+++ b/README.md
@@ -11,11 +11,16 @@ for those who are new to the world of messaging and event sourced domain models.
 All prooph components now ship with `container-interop` compatible factories and therefor provide interoperable framework integration.
 A module, bundle, bridge or whatever is no longer needed to integrate prooph in your web framework of choice.*
 
-## Docs
+## Documentation
 
-- [prooph components](docs/book/components.md)
-- [prooph in a nutshell](docs/book/prooph_in_a_nutshell.md)
-- [component wishlist](docs/book/wishlist.md)
+Documentation is [in the doc tree](docs/), and can be compiled using [bookdown](http://bookdown.io).
+
+```console
+$ php ./vendor/bin/bookdown docs/bookdown.json
+$ php -S 0.0.0.0:8080 -t docs/html/
+```
+
+Then browse to [http://localhost:8080/](http://localhost:8080/)
 
 ## Example Application
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,27 @@
+{
+    "name": "prooph/proophessor",
+    "description": "Exploring prooph components",
+    "type": "library",
+    "license": "BSD-3-Clause",
+    "homepage": "http://getprooph.org/",
+    "authors": [
+        {
+            "name": "Alexander Miertsch",
+            "email": "contact@prooph.de",
+            "homepage": "http://www.prooph.de"
+        },
+        {
+            "name": "Sascha-Oliver Prolic",
+            "email": "saschaprolic@googlemail.com"
+        }
+    ],
+    "keywords": [
+        "EventStore",
+        "EventSourcing",
+        "DDD",
+        "prooph"
+    ],
+    "require-dev": {
+        "tobiju/bookdown-bootswatch-templates": "^0.2.0"
+    }
+}

--- a/docs/book/bookdown.json
+++ b/docs/book/bookdown.json
@@ -1,0 +1,10 @@
+{
+  "title": "Exploring prooph components",
+  "content": [
+    {"prooph-in-a-nutshell": "prooph_in_a_nutshell.md"},
+    {"components": "components.md"},
+    {"wishlist": "wishlist.md"}
+  ],
+  "target": "./html",
+  "template": "../vendor/tobiju/bookdown-bootswatch-templates/templates/cerulean/main.php"
+}

--- a/docs/bookdown.json
+++ b/docs/bookdown.json
@@ -1,0 +1,12 @@
+{
+  "title": "proophessor - Exploring prooph components",
+  "content": [
+    {"proophessor": "book/bookdown.json"},
+    {"service-bus": "https://raw.githubusercontent.com/prooph/service-bus/develop/docs/bookdown.json"},
+    {"event-store": "https://raw.githubusercontent.com/prooph/event-store/develop/docs/bookdown.json"},
+    {"event-store-bus-bridge": "https://raw.githubusercontent.com/prooph/event-store-bus-bridge/develop/docs/bookdown.json"},
+    {"snapshotter": "https://raw.githubusercontent.com/prooph/snapshotter/master/docs/bookdown.json"}
+  ],
+  "target": "./html",
+  "template": "../vendor/tobiju/bookdown-bootswatch-templates/templates/main.php"
+}


### PR DESCRIPTION
This is a WIP, please don't merge.

I've created a prooph components book which loads the other bookdown.io books from the components. It looks nice but maybe the documentation structure should be reorganized.

Here are my thoughts:

* [ ] Same structure over all components (intro, quick start, configuration, ...) like Zend Framework has. This should increase readability for the user
* [ ] Don't link to other md files in documents, because it's a book
* [ ] We need some bash scripts which replaces relative URIs with an absolute URI (images, src files, ...)
* [ ] Support for different versions (bash script)

Bookdown.io has currently some limitations, see [TODO list](https://github.com/bookdown/Bookdown.Bookdown#todo). What do you think?