### PR TITLE
Add fork it on github btn

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ $ docker run -it --rm -p 8080:8080 -v $(pwd):/app php:7.1-cli php -S 0.0.0.0:808
 
 Then browse to [http://localhost:8080/](http://localhost:8080/)
 
+## Remote Docs
+
+We use the remote content feature of bookdown to pull docs from our prooph component repos into a single online documentation.
+This means that if you want to work on the docs - fix spelling, add new pages, improve wording or correct some logical bugs - 
+then take a look at the root [bookdown.json](docs/bookdown.json) to see where the docs are pulled from. Head over to the target
+repository and apply your changes there. Send us a pull request and we manage the rest. Thank you for your help.
+
 ## Example Application
 
 Try out [proophessor-do](https://github.com/prooph/proophessor-do) and [pick up a task](https://github.com/prooph/proophessor-do#learning-by-doing)!

--- a/template/body.php
+++ b/template/body.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * This file is part of the prooph/proophessor.
+ * (c) 2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+$cssBootswatch = getenv('CSS_BOOTSWATCH') ?: 'cerulean';
+
+?>
+<body data-spy="scroll" data-target="#sideNav" data-offset="50" class="bbt-theme-<?php echo $cssBootswatch; ?>">
+<div class="page-wrapper">
+    <?php echo $this->render('core'); ?>
+</div>
+<a href="https://github.com/prooph/proophessor"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
+<?= $this->render("script"); ?>
+</body>

--- a/template/head.php
+++ b/template/head.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * This file is part of the prooph/pdo-event-store.
+ * This file is part of the prooph/proophessor.
  * (c) 2017 prooph software GmbH <contact@prooph.de>
  * (c) 2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *

--- a/template/main.php
+++ b/template/main.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * This file is part of the prooph/pdo-event-store.
+ * This file is part of the prooph/proophessor.
  * (c) 2017 prooph software GmbH <contact@prooph.de>
  * (c) 2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
@@ -30,7 +30,7 @@ $templates->set('head', __DIR__ . '/head.php');
 $templates->set('meta', __DIR__ . '/meta.php');
 $templates->set('style', $templatePath . '/style.php');
 $templates->set('styleProoph', __DIR__ . '/style.php');
-$templates->set('body', $templatePath . '/body.php');
+$templates->set('body', __DIR__ . '/body.php');
 $templates->set('script', $templatePath . '/script.php');
 $templates->set('nav', __DIR__ . '/nav.php');
 $templates->set('core', $templatePath . '/core.php');

--- a/template/meta.php
+++ b/template/meta.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * This file is part of the prooph/pdo-event-store.
+ * This file is part of the prooph/proophessor.
  * (c) 2017 prooph software GmbH <contact@prooph.de>
  * (c) 2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *

--- a/template/nav.php
+++ b/template/nav.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * This file is part of the prooph/pdo-event-store.
+ * This file is part of the prooph/proophessor.
  * (c) 2017 prooph software GmbH <contact@prooph.de>
  * (c) 2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *

--- a/template/style.php
+++ b/template/style.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * This file is part of the prooph/pdo-event-store.
+ * This file is part of the prooph/proophessor.
  * (c) 2017 prooph software GmbH <contact@prooph.de>
  * (c) 2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *


### PR DESCRIPTION
This PR adds a "fork it on github" button. It is copied from here: https://github.com/blog/273-github-ribbons (the black one in top right corner)

Some more ideas are collected in that issue: https://github.com/sandrokeil/bookdown-template/issues/2

For now it is a very simple variant linking only to prooph/proophessor.
I've added a very short explanation how one can find the components docs to edit them.