### PR TITLE
Fix broken links on getprooph.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ This means that if you want to work on the docs - fix spelling, add new pages, i
 then take a look at the root [bookdown.json](docs/bookdown.json) to see where the docs are pulled from. Head over to the target
 repository and apply your changes there. Send us a pull request and we manage the rest. Thank you for your help.
 
+## Deployment (maintainers only)
+
+When generating the docs for getprooph.org deployment you have to add an additional config to the root bookdown.json:
+`"rootHref": "http://getprooph.org/docs/html/",`. See [bookdown.json.prod](docs/bookdown.json.prod).
+The docs are published under `http://getprooph.org/docs/html`. Checkout the `gh-pages` branch of prooph/proophessor and
+copy the generated html into `docs/html` of the gh-pages branch. Commit your changes and push the branch (write access required)
+
 ## Example Application
 
 Try out [proophessor-do](https://github.com/prooph/proophessor-do) and [pick up a task](https://github.com/prooph/proophessor-do#learning-by-doing)!

--- a/docs/bookdown.json.prod
+++ b/docs/bookdown.json.prod
@@ -1,0 +1,25 @@
+{
+    "title": "prooph components documentation",
+    "content": [
+        {"tutorial": "tutorial/bookdown.json"},
+        {"service-bus": "https://raw.githubusercontent.com/prooph/service-bus/master/docs/bookdown.json"},
+        {"event-store": "https://raw.githubusercontent.com/prooph/event-store/master/docs/bookdown.json"},
+        {"event-sourcing": "https://raw.githubusercontent.com/prooph/event-sourcing/master/docs/bookdown.json"}
+    ],
+    "theme": {
+        "toc": {
+            "collapsibleFromLevel": 1
+        }
+    },
+    "tocDepth": 1,
+    "template": "../template/main.php",
+    "target": "./html",
+    "rootHref": "http://getprooph.org/docs/html/",
+    "numbering": false,
+    "extensions": {
+        "commonmark": [
+            "Webuni\\CommonMark\\TableExtension\\TableExtension",
+            "Webuni\\CommonMark\\AttributesExtension\\AttributesExtension"
+        ]
+    }
+}


### PR DESCRIPTION
Had some trouble with the generated links. Bookdown offers a config option `rootHref` but when running the local dev server docs are in the public root and on getprooph.org the docs are in `docs/html`.
Adding a relative path did not work, so a quick fix was to add the absolute url when compiling docs for deployment.

One solution would be to work with a sub domain: docs.getprooph.org (if gh-pages supports it)
@prolic You have control over the domain, right?

Any other ideas @sandrokeil ?