### PR TITLE
Fixed identity comparison

### DIFF
--- a/docs/tutorial/testing_aggregates.md
+++ b/docs/tutorial/testing_aggregates.md
@@ -206,7 +206,7 @@ final class ProductId
             return false;
         }
 
-        return $this->id === $other->id;
+        return $this->toString() === $other->toString();
     }
 
     public function __toString(): string


### PR DESCRIPTION
`id` property on `$other` is not accessible in the provided example, but the `toString()` method returns a string representation of id which can be used to compare identitites.